### PR TITLE
fix: add support for cpu nodes in default cluster configuration

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -161,7 +161,8 @@
                 "required": true
               },
               {
-                "key": "additional_worker_pools"
+                "key": "additional_worker_pools",
+                "required": true
               }
             ],
             "dependencies": [

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -157,10 +157,6 @@
                 ]
               },
               {
-                "key": "default_gpu_worker_pool_storage",
-                "required": true
-              },
-              {
                 "key": "additional_worker_pools",
                 "required": true
               }
@@ -208,11 +204,6 @@
                   {
                     "dependency_input": "default_worker_pool_operating_system",
                     "version_input": "default_worker_pool_operating_system",
-                    "reference_version": true
-                  },
-                  {
-                    "dependency_input": "default_worker_pool_secondary_storage",
-                    "version_input": "default_gpu_worker_pool_storage",
                     "reference_version": true
                   },
                   {

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -25,12 +25,7 @@ variable "existing_resource_group_name" {
 variable "default_worker_pool_machine_type" {
   type        = string
   description = "Specifies the machine type for the default worker pool. This determines the CPU, memory, and disk resources available to each worker node. For OpenShift AI installation, machines should have atleast 8 vcpu, 32GB RAM and GPU. Refer [IBM Cloud documentation for available machine types](https://cloud.ibm.com/docs/openshift?topic=openshift-vpc-flavors)"
-  default     = "gx3.16x80.l4"
-
-  validation {
-    condition     = startswith(var.default_worker_pool_machine_type, "gx2") || startswith(var.default_worker_pool_machine_type, "gx3") || startswith(var.default_worker_pool_machine_type, "gx4")
-    error_message = "The machine type must be from the 'gx2', 'gx3', or 'gx4' series. Please choose a valid machine type with GPU support."
-  }
+  default     = "bx2.8x32"
 
   validation {
     condition     = tonumber(split("x", split(".", var.default_worker_pool_machine_type)[1])[0]) >= 8
@@ -63,13 +58,6 @@ variable "default_worker_pool_operating_system" {
 }
 
 # tflint-ignore: all
-variable "default_gpu_worker_pool_storage" {
-  type        = string
-  description = "Defines the storage configuration for GPU workloads in Red Hat OpenShift AI. This storage is critical for AI/ML workloads, ensuring optimal data processing and model training efficiency. [Learn More](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles&interface=ui#tiers)"
-  default     = "300gb.5iops-tier"
-}
-
-# tflint-ignore: all
 variable "additional_worker_pools" {
   type = list(object({
     vpc_subnets = optional(list(object({
@@ -89,5 +77,38 @@ variable "additional_worker_pools" {
     additional_security_group_ids = optional(list(string))
   }))
   description = "List of additional worker pools with custom configurations to accommodate diverse AI workload requirements within the cluster. [Learn more](https://github.com/terraform-ibm-modules/terraform-ibm-ocp-ai/blob/main/solutions/fully-configurable/DA_docs.md#options-with-worker-pools)"
-  default     = []
+  default = [
+    {
+      pool_name         = "gpu"
+      machine_type      = "gx3.16x80.l4"
+      workers_per_zone  = 2
+      secondary_storage = "300gb.5iops-tier"
+      operating_system  = "RHEL_9_64"
+    },
+  ]
+
+  validation {
+    condition = alltrue([
+      for pool in var.additional_worker_pools : (
+        startswith(pool.machine_type, "gx2") ||
+        startswith(pool.machine_type, "gx3") ||
+        startswith(pool.machine_type, "gx4")
+      )
+    ])
+    error_message = "All machine types must be from the 'gx2', 'gx3', or 'gx4' series. Please choose valid machine types with GPU support."
+  }
+
+  validation {
+    condition = alltrue([
+      for pool in var.additional_worker_pools : tonumber(split("x", split(".", pool.machine_type)[1])[0]) >= 8
+    ])
+    error_message = "To install Red Hat OpenShift AI, all worker nodes in all pools must have at least an 8-core CPU."
+  }
+
+  validation {
+    condition = alltrue([
+      for pool in var.additional_worker_pools : tonumber(split("x", split(".", pool.machine_type)[1])[1]) >= 32
+    ])
+    error_message = "To install Red Hat OpenShift AI, all worker nodes in all pools must have at least 32GB memory."
+  }
 }


### PR DESCRIPTION
### Description

This PR aims to fix the gap in validation by moving GPU configuration to additional worker pool and some minor changes emerged during DA rally syncup.
Issue: [#13375](https://github.ibm.com/GoldenEye/issues/issues/13375)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

* Updated the default worker pool to include non GPU machine types.
* Support for GPU configuration in the additional worker pool.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
