### PR TITLE
feat: Expose region variable

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -140,7 +140,16 @@
             {
               "key": "region",
               "virtual": true,
-              "default_value": "us-south"
+              "required":true,
+              "default_value": "us-south",
+              "custom_config": {
+                "config_constraints": {
+                  "generationType": "2"
+                },
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "type": "vpc_region"
+              }
             },
             {
               "key": "default_worker_pool_operating_system",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -140,8 +140,8 @@
             {
               "key": "region",
               "virtual": true,
-              "required":true,
               "default_value": "us-south",
+              "required": true,
               "custom_config": {
                 "config_constraints": {
                   "generationType": "2"
@@ -237,6 +237,16 @@
                 "*"
               ],
               "input_mapping": [
+                {
+                  "dependency_input": "prefix",
+                  "version_input": "prefix",
+                  "reference_version": true
+                },
+                {
+                  "dependency_input": "existing_resource_group_name",
+                  "version_input": "existing_resource_group_name",
+                  "reference_version": true
+                },
                 {
                   "dependency_input": "region",
                   "version_input": "region",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -138,6 +138,11 @@
               "required": true
             },
             {
+              "key": "region",
+              "virtual": true,
+              "default_value": "us-south"
+            },
+            {
               "key": "default_worker_pool_operating_system",
               "required": true,
               "options": [
@@ -208,8 +213,44 @@
                 }
               ],
               "version": "^v3.43.1"
+            },
+            {
+              "name": "deploy-arch-ibm-vpc",
+              "id": "2af61763-f8ef-4527-a815-b92166f29bc8-global",
+              "version": "^v7.21.0",
+              "flavors": [
+                "fully-configurable"
+              ],
+              "catalog_id": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3",
+              "optional": true,
+              "on_by_default": true,
+              "ignore_auto_referencing": [
+                "*"
+              ],
+              "input_mapping": [
+                {
+                  "dependency_input": "prefix",
+                  "version_input": "prefix",
+                  "reference_version": true
+                },
+                {
+                  "dependency_input": "existing_resource_group_name",
+                  "version_input": "existing_resource_group_name",
+                  "reference_version": true
+                },
+                {
+                  "dependency_input": "region",
+                  "version_input": "region",
+                  "reference_version": true
+                },
+                {
+                  "dependency_output": "vpc_crn",
+                  "version_input": "existing_vpc_crn"
+                }
+              ]
             }
           ],
+
           "dependency_version_2": true
         }
       ]

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -229,23 +229,9 @@
               ],
               "input_mapping": [
                 {
-                  "dependency_input": "prefix",
-                  "version_input": "prefix",
-                  "reference_version": true
-                },
-                {
-                  "dependency_input": "existing_resource_group_name",
-                  "version_input": "existing_resource_group_name",
-                  "reference_version": true
-                },
-                {
                   "dependency_input": "region",
                   "version_input": "region",
                   "reference_version": true
-                },
-                {
-                  "dependency_output": "vpc_crn",
-                  "version_input": "existing_vpc_crn"
                 }
               ]
             }


### PR DESCRIPTION
### Description
Expose region variable in ocp-ai.
<img width="433" alt="image" src="https://github.com/user-attachments/assets/362f649f-de4f-4ae5-b452-ed287310280f" />

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
