### PR TITLE
added ocp_version 4.19 to quickstart ibm_catalog.json

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -836,6 +836,10 @@
               "required": true,
               "options": [
                 {
+                  "displayname": "4.19",
+                  "value": "4.19"
+                },
+                {
                   "displayname": "4.18",
                   "value": "4.18"
                 },


### PR DESCRIPTION
### Description

Added ocp_version 4.19 to quickstart ibm_catalog.json

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added support for ocp_version 4.19

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
